### PR TITLE
Updated HungerOverhaul default.cfg

### DIFF
--- a/config/HungerOverhaul/default.cfg
+++ b/config/HungerOverhaul/default.cfg
@@ -41,52 +41,52 @@
 
 delays {
     # Multiplier applied to the delay between breeding entities [vanilla: 1] [range: 0 ~ 2147483647, default: 4]
-    I:breedingTimeoutMultiplier=4
+    I:breedingTimeoutMultiplier=2
 
     # Multiplier on the time it takes cactus to grow [vanilla: 1] [range: 0 ~ 2147483647, default: 4]
-    I:cactusRegrowthMultiplier=4
+    I:cactusRegrowthMultiplier=2
 
     # Multiplier applied to the delay before children become adults [vanilla: 1] [range: 0 ~ 2147483647, default: 4]
-    I:childDurationMultiplier=4
+    I:childDurationMultiplier=2
 
     # Multiplier on the time it takes cocoa to grow [vanilla: 1] [range: 0 ~ 2147483647, default: 4]
-    I:cocoaRegrowthMultiplier=4
+    I:cocoaRegrowthMultiplier=2
 
     # Multiplier on the time it takes a non-tree crop to grow [vanilla: 1] [range: 0 ~ 2147483647, default: 4]
-    I:cropRegrowthMultiplier=4
+    I:cropRegrowthMultiplier=2
 
     # Multiplier on the time it takes food to dry on Tinkers' Construct drying racks [vanilla: 1] [range: 0 ~ 2147483647, default: 4]
-    I:dryingRackTimeMultiplier=4
+    I:dryingRackTimeMultiplier=2
 
     # Multiplier applied to the delay between chicken egg laying [vanilla: 1] [range: 0 ~ 2147483647, default: 4]
-    I:eggTimeoutMultiplier=4
+    I:eggTimeoutMultiplier=2
 
     # Multiplier on the time it takes a WeeeFlower crop to grow [vanilla: 1] [range: 0 ~ 2147483647, default: 1]
     I:flowerRegrowthMultiplier=1
 
     # Delay (in minutes) after milking a cow before it can be milked again [vanilla: 0] [range: 0 ~ 2147483647, default: 20]
-    I:milkedTimeout=20
+    I:milkedTimeout=5
 
     # Multiplier on the time it takes nether wart to grow [vanilla: 1] [range: 0 ~ 2147483647, default: 4]
-    I:netherWartRegrowthMultiplier=4
+    I:netherWartRegrowthMultiplier=2
 
     # Multipier on crop growth time without sunlight (1 to disable feature, 0 to make crops only grow in sunlight) [vanilla: 1] [range: 0 ~ 2147483647, default: 2]
     I:noSunlightRegrowthMultiplier=2
 
     # Multiplier on the time it takes a sapling to grow into a tree [vanilla: 1] [range: 0 ~ 2147483647, default: 4]
-    I:saplingRegrowthMultiplier=4
+    I:saplingRegrowthMultiplier=2
 
     # Multiplier on the time it takes sugarcane to grow [vanilla: 1] [range: 0 ~ 2147483647, default: 4]
-    I:sugarcaneRegrowthMultiplier=4
+    I:sugarcaneRegrowthMultiplier=2
 
     # Multiplier on the time it takes a tree crop to grow [vanilla: 1] [range: 0 ~ 2147483647, default: 4]
-    I:treeCropRegrowthMultiplier=4
+    I:treeCropRegrowthMultiplier=2
 
     # Multipier on crop growth time (except sugarcane) in the wrong biome (1 to disable feature, 0 to make crops only grow in correct biome) [vanilla: 1] [range: 0 ~ 2147483647, default: 2]
-    I:wrongBiomeRegrowthMultiplier=2
+    I:wrongBiomeRegrowthMultiplier=1
 
     # Multipier on sugarcane growth time in the wrong biome (1 to disable feature, 0 to make sugarcane only grow in correct biome) [vanilla: 1] [range: 0 ~ 2147483647, default: 2]
-    I:wrongBiomeRegrowthMultiplierSugarcane=2
+    I:wrongBiomeRegrowthMultiplierSugarcane=1
 }
 
 
@@ -148,7 +148,7 @@ food {
     B:modifyFoodEatingSpeed=true
 
     # Changes the stack size of food to be dependant on the food's replenishment value [vanilla: false] [default: true]
-    B:modifyFoodStackSize=true
+    B:modifyFoodStackSize=false
 
     # Enables/disables all food value modification [vanilla: false] [default: true]
     B:modifyFoodValues=true
@@ -281,7 +281,7 @@ hunger {
     B:constantHungerLoss=true
 
     # Amount of damage you take when hunger hits zero [vanilla: 2] [range: -2147483648 ~ 2147483647, default: 200]
-    I:damageOnStarve=200
+    I:damageOnStarve=5
 
     # Disable the hunger drain when healing that was introduced in vanilla 1.6.2 [vanilla: false] [default: true]
     B:disableHealingHungerDrain=true


### PR DESCRIPTION
Lowered difficulty of hunger mod:
- Reduced delays in animal breeding and crop growth from 4x delay to 2x delay
- Lowered cow milking timer from 20 minutes to 5 minutes
- Disabled 'wrong biome' growth delay
- Disabled stack size reduction
- Reduced damage taken at zero hunger from 200 to 5 (1/4 of default 20 health allowing 4 hunger ticks before death)
